### PR TITLE
Minimal workaround to fix bug 4831: handles PATH containing '+' characters

### DIFF
--- a/parse/get_fnc.c
+++ b/parse/get_fnc.c
@@ -36,8 +36,24 @@ L1:
 	else
 	{
 	    *EDI++ = AL;
-	    if (!(FNTBL[AL] & FNTBL_ILLEGAL))
+	    if (!(FNTBL[AL] & FNTBL_ILLEGAL) || AL == ' ')
 		goto L1;
+	}
+
+	
+	if(AL == '+') {
+L2:
+		// Skip until the end of this filename so this function returns the start of the next filename
+		AL = *ESI++;
+		if(!(FNTBL[AL] & FNTBL_ILLEGAL) || AL == ' ' || AL == '+') {
+			*EDI++ = AL;
+			goto L2;
+		}
+		*EDI = '\0'; // Set terminating NULL to print to stdout
+		//printf("[WARNING] Filename '%s' contained the '+' character, ommiting it from the filename list\n", &ECX->NFN_TEXT[0]);
+		ECX->NFN_TOTAL_LENGTH = 0; // Get rid of the filename
+		return ESI;
+
 	}
 
 	--ESI;


### PR DESCRIPTION
I created a potential workaround for the issue of the PATH environment variable containing '+' characters.  If I understand the code correctly, I believe this workaround will silently ignore any folders in the path that contain the '+' character. I would anticipate this most likely occurring on anyone who has notepad++ installed and in their PATH directory.  I've included a commented printf statement if anyone wants to use it to verify that the change detects the '+' sign correctly.

Bug Here: https://issues.dlang.org/show_bug.cgi?id=4831